### PR TITLE
Split formatting of the output message out of #format

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -23,7 +23,11 @@ class SimpleCov::Formatter::HTMLFormatter
     File.open(File.join(output_path, "index.html"), "w+") do |file|
       file.puts template('layout').result(binding)
     end
-    puts "Coverage report generated for #{result.command_name} to #{output_path}. #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
+    puts output_message(result)
+  end
+
+  def output_message(result)
+    "Coverage report generated for #{result.command_name} to #{output_path}. #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
   end
   
   private


### PR DESCRIPTION
Split formatting of the output message out of #format so it can be overriden cleanly by subclasses. This does not change the behaviour of this class.

For example, I currently have do the following in one of my projects which is
clearly suboptimal:

```
class MyFormatter < SimpleCov::Formatter::HTMLFormatter
  def format(result)
    Dir[File.join(File.dirname(__FILE__), '../assets/*')].each do |path|
      FileUtils.cp_r(path, asset_output_path)
    end

    File.open(File.join(output_path, "index.html"), "w+") do |file|
      file.puts template('layout').result(binding)
    end

    # ONLY BELOW THIS LINE HAS CHANGED
    puts "Coverage report generated at #{output_path[FileUtils.pwd.length+1..-1]}/index.html for:"
    puts result.command_name.split(', ').map {|x| '  ' + x.split(' ', 2).last }
    puts
    puts "#{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
  end
end
```
