### PR TITLE
Add coverage strength metric

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -9,7 +9,8 @@ $(document).ready(function() {
 			null,
 			null,
 			null,
-			null
+			null,
+      null
 		]
   });
   

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -65,7 +65,14 @@ class SimpleCov::Formatter::HTMLFormatter
     
     lines_covered(file_list) * 100 / lines_of_code(file_list).to_f
   end
-  
+
+  # Computes the strength based upon lines covered and lines missed
+  def strength(file_list)
+    return 0 if file_list.length == 0 or lines_of_code(file_list) == 0
+    strength = file_list.map {|f| f.covered_strength }.inject(&:+)
+    strength / file_list.size
+  end
+
   def lines_of_code(file_list)
     lines_missed(file_list) + lines_covered(file_list)
   end

--- a/views/file_list.erb
+++ b/views/file_list.erb
@@ -1,7 +1,8 @@
 <div class="file_list_container" id="<%= title.gsub(/[^a-zA-Z]/, '') %>">
   <h2>
     <%= title %>
-    (<span class="<%= coverage_css_class(coverage(source_files)) %>"><%= coverage(source_files).round(2) %>%</span>)
+    (<span class="<%= coverage_css_class(coverage(source_files)) %>"><%= coverage(source_files).round(2) %>%</span> x
+     <span class="<%= coverage_css_class(coverage(source_files)) %>"><%= strength(source_files).round(2) %></span>)
   </h2>
   <a name="<%= title.gsub(/[^a-zA-Z]/, '') %>"></a>
   <div>
@@ -19,6 +20,7 @@
         <th>Relevant Lines</th>
         <th>Lines covered</th>
         <th>Lines missed</th>
+        <th>Strength multiple</th>
       </tr>
     </thead>
     <tbody>
@@ -30,6 +32,7 @@
         <td><%= source_file.covered_lines.count + source_file.missed_lines.count %></td>
         <td><%= source_file.covered_lines.count %></td>
         <td><%= source_file.missed_lines.count %></td>
+        <td><%= source_file.covered_strength %></td>
       </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
This is a pull request for the HTML template to go along with the corresponding request to simplecov, which adds a `coverage_strength` metric. You may want to adjust the layout of the toplevel metric, as that is rather subjective. Currently it is given next to the percentage after an `x`, to convey that it is a "multiple", e.g (`90.4% x 4.1`)
