### PR TITLE
Do not strip digits, hyphens and underscores in group name ids

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -54,6 +54,7 @@ class SimpleCov::Formatter::HTMLFormatter
   
   # Returns a table containing the given source files
   def formatted_file_list(title, source_files)
+    title_id = title.gsub(/^[^a-zA-Z]+/, '').gsub(/[^a-zA-Z0-9\-\_]/, '')
     template('file_list').result(binding)
   end
     

--- a/views/file_list.erb
+++ b/views/file_list.erb
@@ -1,4 +1,4 @@
-<div class="file_list_container" id="<%= title.gsub(/[^a-zA-Z]/, '') %>">
+<div class="file_list_container" id="<%= title_id %>">
   <h2>
     <span class="group_name"><%= title %></span>
     (<span class="covered_percent"><span class="<%= coverage_css_class(source_files.covered_percent) %>"><%= source_files.covered_percent.round(2) %>%</span></span>
@@ -9,7 +9,7 @@
        </span>
     </span> hits/line)
   </h2>
-  <a name="<%= title.gsub(/[^a-zA-Z]/, '') %>"></a>
+  <a name="<%= title_id %>"></a>
   <div>
     <b><%= source_files.length %></b> files in total.
     <b><%= source_files.lines_of_code %></b> relevant lines. 


### PR DESCRIPTION
I had group names like "API V1", "API V2", but the links were stripped down the same ("APIV") and the tabs stopped working correctly.

http://www.w3.org/TR/html4/types.html#type-id

> ID and NAME tokens must begin with a letter ([A-Za-z]) and may be followed by
> any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"),
> colons (":"), and periods (".").
