### PR TITLE
remove unassigned variable warning

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -54,7 +54,8 @@ class SimpleCov::Formatter::HTMLFormatter
 
   # Returns a table containing the given source files
   def formatted_file_list(title, source_files)
-    title_id = title.gsub(/^[^a-zA-Z]+/, '').gsub(/[^a-zA-Z0-9\-\_]/, '')
+    # without assignment, throws a warning
+    title_id = title_id = title.gsub(/^[^a-zA-Z]+/, '').gsub(/[^a-zA-Z0-9\-\_]/, '')
     template('file_list').result(binding)
   end
 


### PR DESCRIPTION
We need to assign a variable, but not 'use' it, because
it's going to be picked up in the . So just double
assign. No more warning.
