### PR TITLE
Fix warning in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
The Bundler team recommends that you switch to using a string
rather than the magic constant :rubygems, which will get removed
eventually.
