### PR TITLE
Remove warning about unused local variable.

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -55,8 +55,21 @@ class SimpleCov::Formatter::HTMLFormatter
   # Returns a table containing the given source files
   def formatted_file_list(title, source_files)
     title_id = title.gsub(/^[^a-zA-Z]+/, '').gsub(/[^a-zA-Z0-9\-\_]/, '')
-    title_id # Ruby will give a warning when we do not use this except via the binding :( FIXME
-    template('file_list').result(binding)
+    data = FileListData.new(title, title_id, source_files)
+    template('file_list').result(data.instance_eval { binding })
+  end
+
+  FileListData = Class.new(BasicObject) do
+    attr_reader :title, :title_id, :source_files
+    def initialize(title, title_id, source_files)
+      @title = title
+      @title_id = title_id
+      @source_files = source_files
+    end
+
+    def binding
+      ::Kernel.binding
+    end
   end
 
   def coverage_css_class(covered_percent)


### PR DESCRIPTION
This removes the warning that was occurring by passing the `HTMLFormatter#binding` to a erb template without using that variable in the method.

The binding given to the erb template is that of a basic object that has no methods or variables apart from accessor methods. This hides the internals of`HTMLFormatter` from the ERB template.

This change was tested locally against the cucumber-ruby-core project.

Please consider a 0.8.1 release as this warning has propagated down to other projects that depend on simplecov-html.
