### PR TITLE
fix showing/hiding of elements for colorbox

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -48,6 +48,8 @@ $(document).ready(function() {
       prev_anchor = curr_anchor ? curr_anchor : jQuery.url.attr('anchor');
       curr_anchor = this.href.split('#')[1];
       window.location.hash = curr_anchor;
+
+      $('.file_list_container').hide();
     },
     onCleanup: function() {
       if (prev_anchor && prev_anchor != curr_anchor) {
@@ -59,6 +61,9 @@ $(document).ready(function() {
         curr_anchor = "#_AllFiles";
       }
       window.location.hash = curr_anchor;
+
+      var active_group = $('.group_tabs li.active a').attr('class');
+      $("#" + active_group + ".file_list_container").show();
     }
   });
 

--- a/public/application.js
+++ b/public/application.js
@@ -1628,6 +1628,8 @@ $(document).ready(function() {
       prev_anchor = curr_anchor ? curr_anchor : jQuery.url.attr('anchor');
       curr_anchor = this.href.split('#')[1];
       window.location.hash = curr_anchor;
+
+      $('.file_list_container').hide();
     },
     onCleanup: function() {
       if (prev_anchor && prev_anchor != curr_anchor) {
@@ -1639,6 +1641,9 @@ $(document).ready(function() {
         curr_anchor = "#_AllFiles";
       }
       window.location.hash = curr_anchor;
+
+      var active_group = $('.group_tabs li.active a').attr('class');
+      $("#" + active_group + ".file_list_container").show();
     }
   });
 


### PR DESCRIPTION
This PR fixes the off-screen scrolling with a long file-list-container and a short sourcecode-colorbox.
The effect was that, once one is finished scrolling in the colorbox, the scroll would go past the box, and continue to scroll into a big black area, which was supposed to be the file-list-container (but it is black because of the colorbox).

Basically once the colorbox is displayed, the all file-list-container are hidden, and redisplayed after the colorbox is closed. This eliminates the black area underneath the colorbox and eliminates the off-screen-scrolling bug.
