### PR TITLE
fix: close link tag

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -4,7 +4,7 @@
     <title>Code coverage for <%= SimpleCov.project_name %></title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <script src='<%= assets_path('application.js') %>' type='text/javascript'></script>    
-    <link href='<%= assets_path('application.css') %>' media='screen, projection, print' rel='stylesheet' type='text/css'>
+    <link href='<%= assets_path('application.css') %>' media='screen, projection, print' rel='stylesheet' type='text/css' />
     <link rel="shortcut icon" type="image/png" href="<%= assets_path("favicon_#{coverage_css_class(result.source_files.covered_percent)}.png") %>" />
     <link rel="icon" type="image/png" href="<%= assets_path('favicon.png') %>" />
   </head>


### PR DESCRIPTION
fixes xml parsing error when serving the file as xhtml+xml content type

This was causing me problems when serving from s3. I uploaded using s3_website, which sets the
content type as xhtml+xml. Firefox throws a xml parse error due to one of link tags being unclosed.
