### PR TITLE
Fix "warning: possibly useless use of a variable in void context"

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -66,8 +66,10 @@ class SimpleCov::Formatter::HTMLFormatter
 
   # Returns a table containing the given source files
   def formatted_file_list(title, source_files)
-    title_id = title.gsub(/^[^a-zA-Z]+/, '').gsub(/[^a-zA-Z0-9\-\_]/, '')
-    title_id # Ruby will give a warning when we do not use this except via the binding :( FIXME
+    # Silence a warning by using the following variable to assign to itself:
+    # "warning: possibly useless use of a variable in void context"
+    # The variable is used by ERB via binding.
+    title_id = title_id = title.gsub(/^[^a-zA-Z]+/, '').gsub(/[^a-zA-Z0-9\-\_]/, '')
     template('file_list').result(binding)
   end
 


### PR DESCRIPTION
Uses double assignment as suggested by @robertgrimm in #24.
