### PR TITLE
Disable fadeout when navigating backwards to file list.

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -40,6 +40,7 @@ $(document).ready(function() {
   // Set-up of popup for source file views
   $("a.src_link").colorbox({
     transition: "none",
+    fadeOut: 0,
     inline: true,
     opacity: 1,
     width: "95%",

--- a/assets/javascripts/plugins/jquery.colorbox.js
+++ b/assets/javascripts/plugins/jquery.colorbox.js
@@ -1045,9 +1045,8 @@
             trigger(event_cleanup);
             settings.get('onCleanup');
             $window.unbind('.' + prefix);
-            $overlay.fadeTo(settings.get('fadeOut') || 0, 0);
 
-            $box.stop().fadeTo(settings.get('fadeOut') || 0, 0, function () {
+            var closer = function () {
                 $box.hide();
                 $overlay.hide();
                 trigger(event_purge);
@@ -1058,7 +1057,16 @@
                     trigger(event_closed);
                     settings.get('onClosed');
                 }, 1);
-            });
+            };
+
+            var fadeOut = settings.get('fadeOut');
+            if (fadeOut) {
+                $overlay.fadeTo(fadeOut, 0);
+                $box.stop().fadeTo(fadeOut, 0, closer);
+            } else {
+                $box.stop();
+                closer();
+            }
         }
     };
 

--- a/public/application.js
+++ b/public/application.js
@@ -1066,9 +1066,8 @@ var hljs=new function(){function l(o){return o.replace(/&/gm,"&amp;").replace(/<
             trigger(event_cleanup);
             settings.get('onCleanup');
             $window.unbind('.' + prefix);
-            $overlay.fadeTo(settings.get('fadeOut') || 0, 0);
 
-            $box.stop().fadeTo(settings.get('fadeOut') || 0, 0, function () {
+            var closer = function () {
                 $box.hide();
                 $overlay.hide();
                 trigger(event_purge);
@@ -1079,7 +1078,16 @@ var hljs=new function(){function l(o){return o.replace(/&/gm,"&amp;").replace(/<
                     trigger(event_closed);
                     settings.get('onClosed');
                 }, 1);
-            });
+            };
+
+            var fadeOut = settings.get('fadeOut');
+            if (fadeOut) {
+                $overlay.fadeTo(fadeOut, 0);
+                $box.stop().fadeTo(fadeOut, 0, closer);
+            } else {
+                $box.stop();
+                closer();
+            }
         }
     };
 

--- a/public/application.js
+++ b/public/application.js
@@ -1620,6 +1620,7 @@ $(document).ready(function() {
   // Set-up of popup for source file views
   $("a.src_link").colorbox({
     transition: "none",
+    fadeOut: 0,
     inline: true,
     opacity: 1,
     width: "95%",


### PR DESCRIPTION
Forward animation is disabled already, but colorbox fades
its closing which results in animation when navigating backwards.

Requires https://github.com/jackmoore/colorbox/pull/701
for colorbox to properly handle zero fadeOut value.
