### PR TITLE
Fix a issue of rubocop

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -5,7 +5,7 @@ require "digest/sha1"
 require "time"
 
 # Ensure we are using a compatible version of SimpleCov
-major, minor, patch =  SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
+major, minor, patch = SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
 if major < 0 || minor < 9 || patch < 0
   fail "The version of SimpleCov you are using is too old. "\
   "Please update with `gem install simplecov` or `bundle update simplecov`"


### PR DESCRIPTION
# WHAT
Fixed a issue of Rubocop.

## BEFORE
```
.....C..

Offenses:

lib/simplecov-html.rb:8:22: C: Unnecessary spacing detected.
major, minor, patch =  SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
                     ^

8 files inspected, 1 offense detected
```

## AFTER
```
Inspecting 8 files
........

8 files inspected, no offenses detected
```