### PR TITLE
Fix greedy shortened_filename replace

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -96,7 +96,7 @@ module SimpleCov
       end
 
       def shortened_filename(source_file)
-        source_file.filename.gsub(SimpleCov.root, ".").gsub(/^\.\//, "")
+        source_file.filename.sub(SimpleCov.root, ".").gsub(/^\.\//, "")
       end
 
       def link_to_source_file(source_file)


### PR DESCRIPTION
Uses `sub` instead of `gsub` to avoid replacing file paths that include the root, such as the "app" in "application" when the root directory is `/app`.

I noticed this occurring when developing Rails apps within Docker. A codebase mounted at `/app` would cause `application_helper.rb` to be cut to `../helpers.lication_helper.rb` as the original path is `/app/app/helpers/application_helper.rb`. Not a major issue, just looks very odd in the generated coverage report.

Basic example of issue: https://gist.github.com/akamike/393bede2b89645b946c8d95ac4f5bcf9 and screenshot of greedy replace in action (from the app I first noticed this on):

![greedy_replace](https://cloud.githubusercontent.com/assets/95465/16687737/445df902-4512-11e6-8068-23c3fb8aad0f.png)
