### PR TITLE
Added color for color-blind persons

### DIFF
--- a/assets/stylesheets/screen.css.sass
+++ b/assets/stylesheets/screen.css.sass
@@ -191,23 +191,23 @@ td
 
 .source_table
   .covered
-    border-color: #090
+    border-color: #FFFC3B
   .missed
-    border-color: #900
+    border-color: #FD0C1C
   .never
     border-color: black
   .skipped
     border-color: #fc0
   .covered
     &:nth-child(odd)
-      background-color: #CDF2CD
+      background-color: #FFFC3B
     &:nth-child(even)
-      background-color: #DBF2DB
+      background-color: #FFFB00
   .missed
     &:nth-child(odd)
-      background-color: #F7C0C0
+      background-color: #FF6F56
     &:nth-child(even)
-      background-color: #F7CFCF
+      background-color: #FF4459
   .never
     &:nth-child(odd)
       background-color: #efefef


### PR DESCRIPTION
> github.com/colszowka/simplecov/issues/534

It's very hard to find a good red-green combination, I would suggest to change green to yellow.
`http://blog.usabilla.com/how-to-design-for-color-blindness/`

Or maybe use Icons.

<img width="733" alt="screen shot 2016-11-14 at 12 04 11" src="https://cloud.githubusercontent.com/assets/20790833/20262488/af8bcc44-aa62-11e6-8891-6ed0521cba20.png">
