### PR TITLE
Use `each` instead of `each_with_index` in source_file.erb

### DIFF
--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -11,7 +11,7 @@
   
   <pre>
     <ol>
-      <% source_file.lines.each_with_index do |line| %>
+      <% source_file.lines.each do |line| %>
         <li class="<%= line.status %>" data-hits="<%= line.coverage ? line.coverage : '' %>" data-linenumber="<%= line.number %>">
           <% if line.covered? %><span class="hits"><%= line.coverage %></span><% end %>
           <% if line.skipped? %><span class="hits">skipped</span><% end %>


### PR DESCRIPTION
The behavior of `Enumerable#each_with_index` has changed in JRuby 9.1.9.0.

jruby/jruby#4610

This PR used `each` method because it do not use a block variable of index.

The purpose of this change is to fix the following error at simplecov.

colszowka/simplecov#582

Thanks.