### PR TITLE
Fix jruby regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ rvm:
   - ruby-head
   - jruby
   - rbx-2
+  - jruby-9.1.9.0
 
 matrix:
   allow_failures:

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -11,7 +11,7 @@
   
   <pre>
     <ol>
-      <% source_file.lines.each_with_index do |line| %>
+      <% source_file.lines.each_with_index do |line, _index| %>
         <li class="<%= line.status %>" data-hits="<%= line.coverage ? line.coverage : '' %>" data-linenumber="<%= line.number %>">
           <% if line.covered? %><span class="hits"><%= line.coverage %></span><% end %>
           <% if line.skipped? %><span class="hits">skipped</span><% end %>


### PR DESCRIPTION
There is a bug with `each_with_index` when only one block param is defined.