### PR TITLE
Allow library to be used with frozen-string-literals enabled.

### DIFF
--- a/lib/simplecov-html/version.rb
+++ b/lib/simplecov-html/version.rb
@@ -1,27 +1,7 @@
 module SimpleCov
   module Formatter
     class HTMLFormatter
-      VERSION = "0.10.1".dup
-
-      def VERSION.to_a
-        split(".").map(&:to_i)
-      end
-
-      def VERSION.major
-        to_a[0]
-      end
-
-      def VERSION.minor
-        to_a[1]
-      end
-
-      def VERSION.patch
-        to_a[2]
-      end
-
-      def VERSION.pre
-        to_a[3]
-      end
+      VERSION = "0.10.1".freeze
     end
   end
 end

--- a/lib/simplecov-html/version.rb
+++ b/lib/simplecov-html/version.rb
@@ -1,7 +1,7 @@
 module SimpleCov
   module Formatter
     class HTMLFormatter
-      VERSION = "0.10.1"
+      VERSION = "0.10.1".dup
 
       def VERSION.to_a
         split(".").map(&:to_i)


### PR DESCRIPTION
This change ensures that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards). I would recommend adding the following to your `.travis.yml` file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4).