### PR TITLE
CI against JRuby 9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ rvm:
   - ruby-head
   - jruby
   - rbx-2
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates JRuby version on Travis CI.
http://jruby.org/2017/09/06/jruby-9-1-13-0

This PR is the same intention as colszowka/simplecov#621.
