### PR TITLE
Rescue encoding error

### DIFF
--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -54,6 +54,8 @@ module SimpleCov
       # Returns the html for the given source_file
       def formatted_source_file(source_file)
         template("source_file").result(binding)
+      rescue Encoding::CompatibilityError => e
+        puts "Encoding problems with file #{source_file.filename}. Simplecov/ERB can't handle non ASCII characters in filenames. Error: #{e.message}."
       end
 
       # Returns a table containing the given source files


### PR DESCRIPTION
Gives a meaningful message and allows the report to be generated when a file has a non ASCII character. See #439 (https://github.com/colszowka/simplecov/issues/439)