### PR TITLE
TrailingCommaInLiteral was split in rubocop  0.53.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,5 +50,8 @@ Style/SpaceInsideHashLiteralBraces:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: 'comma'


### PR DESCRIPTION
Failed for me on GitLab CI

https://github.com/bbatsov/rubocop/blob/v0.53.0/CHANGELOG.md
https://github.com/bbatsov/rubocop/issues/3394
https://github.com/bbatsov/rubocop/pull/5307/files#diff-e93280b3b31a6438c533a5f3232340d8