### PR TITLE
Add ability to support branch coverage statistics ruby >= 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,15 +31,15 @@ Metrics/ParameterLists:
 
 Naming/FileName:
   Exclude:
-    - 'lib/simplecov-html.rb'
-    - 'test/test_simple_cov-html.rb'
+    - "lib/simplecov-html.rb"
+    - "test/test_simple_cov-html.rb"
 
 Style/CollectionMethods:
   PreferredMethods:
-    map:      'collect'
-    reduce:   'inject'
-    find:     'detect'
-    find_all: 'select'
+    map: "collect"
+    reduce: "inject"
+    find: "detect"
+    find_all: "select"
 
 Style/Documentation:
   Enabled: false
@@ -58,7 +58,7 @@ Style/HashSyntax:
 
 Style/MutableConstant:
   Exclude:
-    - 'lib/simplecov-html/version.rb'
+    - "lib/simplecov-html/version.rb"
 
 Style/NumericPredicate:
   Enabled: false
@@ -73,7 +73,7 @@ Style/SymbolArray:
   Enabled: false
 
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: 'comma'
+  EnforcedStyleForMultiline: "comma"
 
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: 'comma'
+  EnforcedStyleForMultiline: "comma"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,7 @@ bundler_args: --without development --jobs=3 --retry=3
 sudo: false
 
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
+  - 2.4.9
   - 2.5.3
   - 2.6.1
   - jruby-9.2.6.0

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :test do
 end
 
 group :development do
-  gem "rubocop"
+  gem "rubocop", "~> 0.62.0"
   gem "sass"
   gem "sprockets"
 end

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -7,16 +7,7 @@ $(document).ready(function() {
   $('.file_list').dataTable({
     "aaSorting": [[ 1, "asc" ]],
     "bPaginate": false,
-    "bJQueryUI": true,
-    "aoColumns": [
-      null,
-      { "sType": "percent" },
-      null,
-      null,
-      null,
-      null,
-      null
-    ]
+    "bJQueryUI": true
   });
 
   // Syntax highlight all files up front - deactivated

--- a/assets/stylesheets/screen.css.sass
+++ b/assets/stylesheets/screen.css.sass
@@ -188,6 +188,8 @@ td
 
 .yellow
   color: #da0
+.blue
+  color: blue
 
 .source_table
   .covered
@@ -198,6 +200,8 @@ td
     border-color: black
   .skipped
     border-color: #fc0
+  .missed-branch
+    border-color: #bf0000
   .covered
     &:nth-child(odd)
       background-color: #CDF2CD
@@ -218,3 +222,8 @@ td
       background-color: #FBF0C0
     &:nth-child(even)
       background-color: #FBFfCf
+  .missed-branch
+    &:nth-child(odd)
+      background-color: #cc8e8e
+    &:nth-child(even)
+      background-color: #cc6e6e

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -15,6 +15,7 @@ module SimpleCov
   module Formatter
     class HTMLFormatter
       def format(result)
+
         Dir[File.join(File.dirname(__FILE__), "../public/*")].each do |path|
           FileUtils.cp_r(path, asset_output_path)
         end
@@ -27,6 +28,20 @@ module SimpleCov
 
       def output_message(result)
         "Coverage report generated for #{result.command_name} to #{output_path}. #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
+      end
+
+      # Check if branchable results supported or not
+      # Try used here to escape exceptions
+      def branchable_result?
+        defined?(SimpleCov::branchable_report) ? SimpleCov::branchable_report : false
+      end
+
+      def line_status?(source_file, line)
+        if branchable_result? && source_file.line_with_missed_branch?(line.number)
+          "missed-branch"
+        else
+          line.status
+        end
       end
 
     private

--- a/lib/simplecov-html.rb
+++ b/lib/simplecov-html.rb
@@ -15,7 +15,6 @@ module SimpleCov
   module Formatter
     class HTMLFormatter
       def format(result)
-
         Dir[File.join(File.dirname(__FILE__), "../public/*")].each do |path|
           FileUtils.cp_r(path, asset_output_path)
         end
@@ -33,7 +32,9 @@ module SimpleCov
       # Check if branchable results supported or not
       # Try used here to escape exceptions
       def branchable_result?
+        # rubocop:disable Style/ColonMethodCall
         defined?(SimpleCov::branchable_report) ? SimpleCov::branchable_report : false
+        # rubocop:enable Style/ColonMethodCall
       end
 
       def line_status?(source_file, line)

--- a/public/application.css
+++ b/public/application.css
@@ -532,6 +532,7 @@ pre .tex .formula {
     ColorBox Core Style:
     The following CSS is consistent between example themes and should not be altered.
 */
+
 #colorbox, #cboxOverlay, #cboxWrapper{position:absolute; top:0; left:0; z-index:9999; overflow:hidden;}
 #cboxOverlay{position:fixed; width:100%; height:100%;}
 #cboxMiddleLeft, #cboxBottomLeft{clear:left;}
@@ -586,19 +587,19 @@ pre .tex .formula {
   top: 50%; }
 
 a {
-  color: #333333;
+  color: #333;
   text-decoration: none; }
   a:hover {
-    color: black;
+    color: #000;
     text-decoration: underline; }
 
 body {
   font-family: "Lucida Grande", Helvetica, "Helvetica Neue", Arial, sans-serif;
   padding: 12px;
-  background-color: #333333; }
+  background-color: #333; }
 
 h1, h2, h3, h4 {
-  color: #1c2324;
+  color: #1C2324;
   margin: 0;
   padding: 0;
   margin-bottom: 12px; }
@@ -609,8 +610,8 @@ table {
 #content {
   clear: left;
   background-color: white;
-  border: 2px solid #dddddd;
-  border-top: 8px solid #dddddd;
+  border: 2px solid #ddd;
+  border-top: 8px solid #ddd;
   padding: 18px;
   -webkit-border-bottom-left-radius: 5px;
   -webkit-border-bottom-right-radius: 5px;
@@ -632,7 +633,7 @@ abbr.timeago {
 
 .timestamp {
   float: right;
-  color: #dddddd; }
+  color: #ddd; }
 
 .group_tabs {
   list-style: none;
@@ -648,13 +649,13 @@ abbr.timeago {
       float: left;
       text-decoration: none;
       padding: 4px 8px;
-      background-color: #aaaaaa;
+      background-color: #aaa;
       background: -webkit-gradient(linear, 0 0, 0 bottom, from(#dddddd), to(#aaaaaa));
       background: -moz-linear-gradient(#dddddd, #aaaaaa);
       background: linear-gradient(#dddddd, #aaaaaa);
       text-shadow: #e5e5e5 1px 1px 0px;
       border-bottom: none;
-      color: #333333;
+      color: #333;
       font-weight: bold;
       margin-right: 8px;
       border-top: 1px solid #efefef;
@@ -665,7 +666,7 @@ abbr.timeago {
       border-top-left-radius: 2px;
       border-top-right-radius: 2px; }
       .group_tabs li a:hover {
-        background-color: #cccccc;
+        background-color: #ccc;
         background: -webkit-gradient(linear, 0 0, 0 bottom, from(#eeeeee), to(#aaaaaa));
         background: -moz-linear-gradient(#eeeeee, #aaaaaa);
         background: linear-gradient(#eeeeee, #aaaaaa); }
@@ -674,8 +675,8 @@ abbr.timeago {
         padding-bottom: 3px; }
     .group_tabs li.active a {
       color: black;
-      text-shadow: white 1px 1px 0px;
-      background-color: #dddddd;
+      text-shadow: #fff 1px 1px 0px;
+      background-color: #ddd;
       background: -webkit-gradient(linear, 0 0, 0 bottom, from(white), to(#dddddd));
       background: -moz-linear-gradient(white, #dddddd);
       background: linear-gradient(white, #dddddd); }
@@ -713,13 +714,13 @@ td {
   margin: 0;
   padding: 0;
   white-space: normal;
-  color: black;
+  color: #000;
   font-family: "Monaco", "Inconsolata", "Consolas", monospace; }
 .source_table code {
-  color: black;
+  color: #000;
   font-family: "Monaco", "Inconsolata", "Consolas", monospace; }
 .source_table pre {
-  background-color: #333333; }
+  background-color: #333; }
   .source_table pre ol {
     margin: 0px;
     padding: 0px;
@@ -737,7 +738,7 @@ td {
     float: right;
     margin-left: 10px;
     padding: 2px 4px;
-    background-color: #444444;
+    background-color: #444;
     background: -webkit-gradient(linear, 0 0, 0 bottom, from(#222222), to(#666666));
     background: -moz-linear-gradient(#222222, #666666);
     background: linear-gradient(#222222, #666666);
@@ -749,51 +750,60 @@ td {
     border-radius: 6px; }
 
 #footer {
-  color: #dddddd;
+  color: #ddd;
   font-size: 12px;
   font-weight: bold;
   margin-top: 12px;
   text-align: right; }
   #footer a {
-    color: #eeeeee;
+    color: #eee;
     text-decoration: underline; }
     #footer a:hover {
-      color: white;
+      color: #fff;
       text-decoration: none; }
 
 .green {
-  color: #009900; }
+  color: #090; }
 
 .red {
-  color: #990000; }
+  color: #900; }
 
 .yellow {
-  color: #ddaa00; }
+  color: #da0; }
+
+.blue {
+  color: blue; }
 
 .source_table .covered {
-  border-color: #009900; }
+  border-color: #090; }
 .source_table .missed {
-  border-color: #990000; }
+  border-color: #900; }
 .source_table .never {
   border-color: black; }
 .source_table .skipped {
-  border-color: #ffcc00; }
+  border-color: #fc0; }
+.source_table .missed-branch {
+  border-color: #bf0000; }
 .source_table .covered:nth-child(odd) {
-  background-color: #cdf2cd; }
+  background-color: #CDF2CD; }
 .source_table .covered:nth-child(even) {
-  background-color: #dbf2db; }
+  background-color: #DBF2DB; }
 .source_table .missed:nth-child(odd) {
-  background-color: #f7c0c0; }
+  background-color: #F7C0C0; }
 .source_table .missed:nth-child(even) {
-  background-color: #f7cfcf; }
+  background-color: #F7CFCF; }
 .source_table .never:nth-child(odd) {
   background-color: #efefef; }
 .source_table .never:nth-child(even) {
   background-color: #f4f4f4; }
 .source_table .skipped:nth-child(odd) {
-  background-color: #fbf0c0; }
+  background-color: #FBF0C0; }
 .source_table .skipped:nth-child(even) {
-  background-color: #fbffcf; }
+  background-color: #FBFfCf; }
+.source_table .missed-branch:nth-child(odd) {
+  background-color: #cc8e8e; }
+.source_table .missed-branch:nth-child(even) {
+  background-color: #cc6e6e; }
 
 
 

--- a/public/application.js
+++ b/public/application.js
@@ -1587,16 +1587,7 @@ $(document).ready(function() {
   $('.file_list').dataTable({
     "aaSorting": [[ 1, "asc" ]],
     "bPaginate": false,
-    "bJQueryUI": true,
-    "aoColumns": [
-      null,
-      { "sType": "percent" },
-      null,
-      null,
-      null,
-      null,
-      null
-    ]
+    "bJQueryUI": true
   });
 
   // Syntax highlight all files up front - deactivated

--- a/views/file_list.erb
+++ b/views/file_list.erb
@@ -1,21 +1,40 @@
 <div class="file_list_container" id="<%= title_id %>">
   <h2>
     <span class="group_name"><%= title %></span>
-    (<span class="covered_percent"><span class="<%= coverage_css_class(source_files.covered_percent) %>"><%= source_files.covered_percent.round(2) %>%</span></span>
+    (<span class="covered_percent">
+      <span class="<%= coverage_css_class(source_files.covered_percent) %>">
+        <%= source_files.covered_percent.round(2) %>%
+      </span>
+     </span>
      covered at
      <span class="covered_strength">
        <span class="<%= strength_css_class(source_files.covered_strength) %>">
          <%= source_files.covered_strength.round(2) %>
        </span>
-    </span> hits/line)
+    </span> hits/line
+    )
   </h2>
+
   <a name="<%= title_id %>"></a>
+
   <div>
     <b><%= source_files.length %></b> files in total.
-    <b><%= source_files.lines_of_code %></b> relevant lines. 
-    <span class="green"><b><%= source_files.covered_lines %></b> lines covered</span> and
-    <span class="red"><b><%= source_files.missed_lines %></b> lines missed </span>
   </div>
+
+  <div>
+    <b><%= source_files.lines_of_code %></b> relevant lines,
+    <span class="green"><b><%= source_files.covered_lines %></b> lines covered</span> and
+    <span class="red"><b><%= source_files.missed_lines %></b> lines missed. </span>
+  </div>
+
+  <% if branchable_result? %>
+    <div>
+      <span><b><%= source_files.total_branches %></b> total branches, </span>
+      <span class="green"><b><%= source_files.covered_branches %></b> branches covered</span> and
+      <span class="red"><b><%= source_files.missed_branches %></b> branches missed.</span>
+    </div>
+  <% end %>
+
   <table class="file_list">
     <thead>
       <tr>
@@ -26,6 +45,11 @@
         <th>Lines covered</th>
         <th>Lines missed</th>
         <th>Avg. Hits / Line</th>
+        <% if branchable_result? %>
+          <th>Branches</th>
+          <th>Covered branches</th>
+          <th>Missed branches </th>
+        <% end %>
       </tr>
     </thead>
     <tbody>
@@ -38,6 +62,11 @@
         <td><%= source_file.covered_lines.count %></td>
         <td><%= source_file.missed_lines.count %></td>
         <td><%= source_file.covered_strength %></td>
+        <% if branchable_result? %>
+          <td><%= source_file.total_branches.count %></td>
+          <td><%= source_file.covered_branches.count %></td>
+          <td><%= source_file.missed_branches.count %></td>
+        <% end %>
       </tr>
       <% end %>
     </tbody>

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -10,8 +10,8 @@
 
     <% if branchable_result? %>
       <h4>
-        <span class="<%= coverage_css_class(source_file.branches_coverage_precent) %>">
-          <%= source_file.branches_coverage_precent.round(2).to_s %> %
+        <span class="<%= coverage_css_class(source_file.branches_coverage_percent) %>">
+          <%= source_file.branches_coverage_percent.round(2).to_s %> %
         </span>
         branches covered
       </h4>

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -1,22 +1,57 @@
 <div class="source_table" id="<%= id source_file %>">
   <div class="header">
     <h3><%= shortened_filename source_file %></h3>
-    <h4><span class="<%= coverage_css_class(source_file.covered_percent) %>"><%= source_file.covered_percent.round(2).to_s %> %</span> covered</h4>
+    <h4>
+      <span class="<%= coverage_css_class(source_file.covered_percent) %>">
+        <%= source_file.covered_percent.round(2).to_s %> %
+      </span>
+      lines covered
+    </h4>
+
+    <% if branchable_result? %>
+      <h4>
+        <span class="<%= coverage_css_class(source_file.branches_coverage_precent) %>">
+          <%= source_file.branches_coverage_precent.round(2).to_s %> %
+        </span>
+        branches covered
+      </h4>
+    <% end %>
+
     <div>
-      <b><%= source_file.lines_of_code %></b> relevant lines. 
+      <b><%= source_file.lines_of_code %></b> relevant lines.
       <span class="green"><b><%= source_file.covered_lines.count %></b> lines covered</span> and
       <span class="red"><b><%= source_file.missed_lines.count %></b> lines missed.</span>
     </div>
+
+    <div>
+      <% if branchable_result? %>
+        <span><b><%= source_file.total_branches.count %></b> total branches, </span>
+        <span class="green"><b><%= source_file.covered_branches.count %></b> branches covered</span> and
+        <span class="red"><b><%= source_file.missed_branches.count %></b> branches missed.</span>
+      <% end %>
+    </div>
+
   </div>
-  
+
   <pre>
     <ol>
       <% source_file.lines.each do |line| %>
-        <li class="<%= line.status %>" data-hits="<%= line.coverage ? line.coverage : '' %>" data-linenumber="<%= line.number %>">
-          <% if line.covered? %><span class="hits"><%= line.coverage %></span><% end %>
-          <% if line.skipped? %><span class="hits">skipped</span><% end %>
-          <code class="ruby"><%= CGI.escapeHTML(line.src.chomp) %></code>
-        </li>
+        <div>
+          <li class="<%= line_status?(source_file, line) %>" data-hits="<%= line.coverage ? line.coverage : '' %>" data-linenumber="<%= line.number %>">
+            <% if line.covered? %><span class="hits"><%= line.coverage %></span><% end %>
+            <% if line.skipped? %><span class="hits">skipped</span><% end %>
+
+            <% if branchable_result? %>
+              <% if source_file.branchable_line?(line.number) %>
+                <span class="hits">
+                  <%= source_file.branch_per_line(line.number) %>
+                </span>
+              <% end %>
+            <% end %>
+
+            <code class="ruby"><%= CGI.escapeHTML(line.src.chomp) %></code>
+          </li>
+        </div>
       <% end %>
     </ol>
   </pre>


### PR DESCRIPTION
Show statistics of branch coverage result.
![branch1](https://user-images.githubusercontent.com/7699543/43397336-22e3bd92-940d-11e8-8290-fcedc9045689.png)
![all_files](https://user-images.githubusercontent.com/7699543/43397386-51b62b82-940d-11e8-884e-3dfd188700ef.png)
You can put this merge on pending until they [merge](https://github.com/colszowka/simplecov/pull/692) `simplecov` gem branch that generates needed statistics. Anyway, these modifications are not harmful.