### PR TITLE
Make file list horizontal-scrollable on small screen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,10 @@ bundler_args: --without development --jobs=3 --retry=3
 sudo: false
 
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
-  - jruby-9.2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
+  - jruby-9.2.7.0
   - ruby-head
   - jruby-head
 

--- a/assets/stylesheets/screen.css.sass
+++ b/assets/stylesheets/screen.css.sass
@@ -101,6 +101,9 @@ abbr.timeago
 .file_list
   margin-bottom: 18px
 
+.file_list-responsive
+  overflow-x: scroll
+
 a.src_link
   background: url('./magnify.png') no-repeat left 50%
   padding-left: 18px

--- a/public/application.css
+++ b/public/application.css
@@ -683,6 +683,9 @@ abbr.timeago {
 .file_list {
   margin-bottom: 18px; }
 
+.file_list-responsive {
+  overflow-x: scroll; }
+
 a.src_link {
   background: url("./magnify.png") no-repeat left 50%;
   padding-left: 18px; }

--- a/views/file_list.erb
+++ b/views/file_list.erb
@@ -12,34 +12,36 @@
   <a name="<%= title_id %>"></a>
   <div>
     <b><%= source_files.length %></b> files in total.
-    <b><%= source_files.lines_of_code %></b> relevant lines. 
+    <b><%= source_files.lines_of_code %></b> relevant lines.
     <span class="green"><b><%= source_files.covered_lines %></b> lines covered</span> and
     <span class="red"><b><%= source_files.missed_lines %></b> lines missed </span>
   </div>
-  <table class="file_list">
-    <thead>
-      <tr>
-        <th>File</th>
-        <th>% covered</th>
-        <th>Lines</th>
-        <th>Relevant Lines</th>
-        <th>Lines covered</th>
-        <th>Lines missed</th>
-        <th>Avg. Hits / Line</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% source_files.each do |source_file| %>
-      <tr>
-        <td class="strong"><%= link_to_source_file(source_file) %></td>
-        <td class="<%= coverage_css_class(source_file.covered_percent) %> strong"><%= source_file.covered_percent.round(2).to_s %> %</td>
-        <td><%= source_file.lines.count %></td>
-        <td><%= source_file.covered_lines.count + source_file.missed_lines.count %></td>
-        <td><%= source_file.covered_lines.count %></td>
-        <td><%= source_file.missed_lines.count %></td>
-        <td><%= source_file.covered_strength %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="file_list-responsive">
+    <table class="file_list">
+      <thead>
+        <tr>
+          <th>File</th>
+          <th>% covered</th>
+          <th>Lines</th>
+          <th>Relevant Lines</th>
+          <th>Lines covered</th>
+          <th>Lines missed</th>
+          <th>Avg. Hits / Line</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% source_files.each do |source_file| %>
+        <tr>
+          <td class="strong"><%= link_to_source_file(source_file) %></td>
+          <td class="<%= coverage_css_class(source_file.covered_percent) %> strong"><%= source_file.covered_percent.round(2).to_s %> %</td>
+          <td><%= source_file.lines.count %></td>
+          <td><%= source_file.covered_lines.count + source_file.missed_lines.count %></td>
+          <td><%= source_file.covered_lines.count %></td>
+          <td><%= source_file.missed_lines.count %></td>
+          <td><%= source_file.covered_strength %></td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
Existing file list in the HTML report overflows on small screen (see screenshot below):
<img width="521" alt="Screenshot 2019-11-05 at 12 03 17 PM" src="https://user-images.githubusercontent.com/164703/68177876-b3662700-ffc4-11e9-9f23-acb2174fce5d.png">


This patch make the file list **scrollable horizontally** on small screen:
<img width="354" alt="Screenshot 2019-11-05 at 12 03 56 PM" src="https://user-images.githubusercontent.com/164703/68177872-ae08dc80-ffc4-11e9-8d53-0ddff58c5c6b.png">
