### PR TITLE
Fix UTF8 encoding error

### DIFF
--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -45,7 +45,7 @@
               <% end %>
             <% end %>
 
-            <code class="ruby"><%= CGI.escapeHTML(line.src.chomp) %></code>
+            <code class="ruby"><%= CGI.escapeHTML(line.src.chomp.encode('UTF-8', invalid: :replace, undef: :replace)) %></code>
           </li>
         </div>
       <% end %>


### PR DESCRIPTION
`concat': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)

replaces #45 