### PR TITLE
Revert encoding replace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ PATH
 PATH
   remote: /home/tobi/github/simplecov
   specs:
-    simplecov (0.18.1)
+    simplecov (0.18.2)
       docile (~> 1.1)
-      simplecov-html (~> 0.11.0)
+      simplecov-html (~> 0.11)
 
 GEM
   remote: https://rubygems.org/

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -45,7 +45,7 @@
               <% end %>
             <% end %>
 
-            <code class="ruby"><%= CGI.escapeHTML(line.src.chomp.encode('UTF-8', invalid: :replace, undef: :replace)) %></code>
+            <code class="ruby"><%= CGI.escapeHTML(line.src.chomp) %></code>
           </li>
         </div>
       <% end %>


### PR DESCRIPTION
This reverts commit 2608b9d.

Replaced by: colszowka/simplecov#866
As suggested by: #91 (comment)
Should be safe to revert as apparently ruby itself doesn't work
when the encoding isn't declared properly so should be good.

For files that aren't required by ruby but tracked we added a
test case with broken encoding (in simplecov main) but it still
seems to work.  So this complexity is likely not needed anymore.

