### PR TITLE
Fix "missed branch" background color

### DIFF
--- a/assets/stylesheets/screen.css.sass
+++ b/assets/stylesheets/screen.css.sass
@@ -237,6 +237,6 @@ thead
       background-color: #FBFfCf
   .missed-branch
     &:nth-child(odd)
-      background-color: #cc8e8e
+      background-color: #ffddbb
     &:nth-child(even)
-      background-color: #cc6e6e
+      background-color: #ffccaa

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -32,8 +32,8 @@
   <pre>
     <ol>
       <% source_file.lines.each do |line| %>
-        <div>
-          <li class="<%= line_status?(source_file, line) %>" data-hits="<%= line.coverage ? line.coverage : '' %>" data-linenumber="<%= line.number %>">
+        <div class="<%= line_status?(source_file, line) %>">
+          <li data-hits="<%= line.coverage ? line.coverage : '' %>" data-linenumber="<%= line.number %>">
             <% if line.covered? %><span class="hits"><%= line.coverage %></span><% end %>
             <% if line.skipped? %><span class="hits">skipped</span><% end %>
 


### PR DESCRIPTION
First, thanks for the new release, with the new branch coverage support

I noticed that the choice of background color can sometimes be problematic, due to the syntax highlighting of the code. The comments are not supposed to be executed but the syntax highlighting is not perfect and sometimes code is rendered as comment when it's not. If you have a `.missed-branch` style on that, this becomes unreadable:

![image](https://user-images.githubusercontent.com/153279/79158259-4a39d980-7dd6-11ea-91a1-e8ca3075e6f0.png)

So I propose this one instead:

![image](https://user-images.githubusercontent.com/153279/79158296-5887f580-7dd6-11ea-8250-0601bc2d3044.png)

At the occasion of tweaking the CSS, I noticed that only the `.missed-branch:nth-child(odd)` was ever used... which lead to a follow-up change, moving the status class from the `<li>` to its parent `<div>`.
 